### PR TITLE
Fix BTF emission

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -39,7 +39,7 @@ const bpffunction_cache = Dict{UInt,Any}()
 
 # actual compilation
 function bpffunction_compile(source::FunctionSpec; format=:obj, license="",
-                             prog_section="prog", btf=false, kwargs...)
+                             prog_section="prog", btf=true, kwargs...)
     # compile to BPF
     target = BPFCompilerTarget(; license, prog_section)
     params = BPFCompilerParams()

--- a/src/probes.jl
+++ b/src/probes.jl
@@ -10,7 +10,7 @@ struct KProbe <: AbstractProbe
     retprobe::Bool
 end
 function KProbe(f::Function, kfunc; retprobe=false, kwargs...)
-    obj = API.Object(bpffunction(f, Tuple{API.pointertype(API.pt_regs)}; btf=false, kwargs...))
+    obj = API.Object(bpffunction(f, Tuple{API.pointertype(API.pt_regs)}; kwargs...))
     foreach(prog->API.set_kprobe!(prog), API.programs(obj))
     KProbe(obj, kfunc, retprobe)
 end
@@ -21,7 +21,7 @@ struct UProbe{F<:Function,T} <: AbstractProbe
     retprobe::Bool
 end
 function UProbe(f::Function, method, sig; retprobe=false, kwargs...)
-    obj = API.Object(bpffunction(f, Tuple{API.pointertype(API.pt_regs)}; btf=false, kwargs...))
+    obj = API.Object(bpffunction(f, Tuple{API.pointertype(API.pt_regs)}; kwargs...))
     #foreach(prog->API.set_uprobe!(prog), API.programs(obj))
     foreach(prog->API.set_kprobe!(prog), API.programs(obj))
     UProbe(obj, method, sig, retprobe)
@@ -32,7 +32,7 @@ struct Tracepoint <: AbstractProbe
     name::String
 end
 function Tracepoint(f::Function, category, name; kwargs...)
-    obj = API.Object(bpffunction(f, Tuple{API.pointertype(API.pt_regs)}; btf=false, kwargs...))
+    obj = API.Object(bpffunction(f, Tuple{API.pointertype(API.pt_regs)}; kwargs...))
     foreach(prog->API.set_tracepoint!(prog), API.programs(obj))
     Tracepoint(obj, category, name)
 end


### PR DESCRIPTION
This re-enables BTF, fixing a test in the process. We need to fix-up our BTF so that the kernel likes it, which may require us to manually clean-up debuginfo.