### PR TITLE
API: Add BPF capabilities utility

### DIFF
--- a/src/BPFnative.jl
+++ b/src/BPFnative.jl
@@ -46,6 +46,7 @@ end
 include("utils.jl")
 include("common.jl")
 include("libbpf.jl")
+include("libcap.jl")
 if Sys.islinux()
 include("network.jl")
 end

--- a/src/libcap.jl
+++ b/src/libcap.jl
@@ -1,0 +1,17 @@
+const libcap = "/usr/lib/libcap.so"
+
+const CAP_PERFMON = Cint(39)
+const CAP_BPF = Cint(39)
+const CAP_EFFECTIVE = Cint(0)
+const CAP_SET = Cint(1)
+
+function add_cap_bpf!()
+    caps = ccall((:cap_get_proc, libcap), Ptr{Cvoid}, ())
+    cap_list = [CAP_BPF,CAP_PERFMON]
+    @assert ccall((:cap_set_flag, libcap), Cint,
+                  (Ptr{Cvoid}, Cint, Cint, Ptr{Cvoid}, Cint),
+                  caps, CAP_EFFECTIVE, length(cap_list), cap_list, CAP_SET) != 1
+    @assert ccall((:cap_set_proc, libcap), Cint, (Ptr{Cvoid},), caps) != -1
+    @assert ccall((:cap_free, libcap), Cint, (Ptr{Cvoid},), caps) != -1
+    return
+end


### PR DESCRIPTION
This makes it possible to use privileged BPF features without running as root, assuming Julia's executable file or process has the appropriate capabilities.

Todo:
- [ ] Add `bpf-exec` utility to `contrib/`
- [ ] Attempt to set capabilities automatically during tests
- [ ] Check for appropriate capabilities in CI root tests
- [ ] Add `CAP_NET_ADMIN`
- [ ] Use CBinding to get constants and functions